### PR TITLE
Ensure upload_file returns a tuple

### DIFF
--- a/importer_client/python/tools/timesketch_importer.py
+++ b/importer_client/python/tools/timesketch_importer.py
@@ -21,7 +21,7 @@ import os
 import sys
 import time
 
-from typing import Dict
+from typing import Dict, Tuple
 
 from timesketch_api_client import cli_input
 from timesketch_api_client import credentials as ts_credentials
@@ -61,7 +61,7 @@ def configure_logger_default():
 
 def upload_file(
     my_sketch: sketch.Sketch, config_dict: Dict[str, any], file_path: str
-) -> tuple[str, int]:
+) -> Tuple[str, int]:
     """Uploads a file to Timesketch.
 
     Args:

--- a/importer_client/python/tools/timesketch_importer.py
+++ b/importer_client/python/tools/timesketch_importer.py
@@ -61,7 +61,7 @@ def configure_logger_default():
 
 def upload_file(
     my_sketch: sketch.Sketch, config_dict: Dict[str, any], file_path: str
-) -> str, int:
+) -> tuple[str, int]:
     """Uploads a file to Timesketch.
 
     Args:

--- a/importer_client/python/tools/timesketch_importer.py
+++ b/importer_client/python/tools/timesketch_importer.py
@@ -61,7 +61,7 @@ def configure_logger_default():
 
 def upload_file(
     my_sketch: sketch.Sketch, config_dict: Dict[str, any], file_path: str
-) -> str:
+) -> str, int:
     """Uploads a file to Timesketch.
 
     Args:
@@ -74,10 +74,12 @@ def upload_file(
         A tuple with the timeline object (timeline.Timeline) or None if not
         able to upload the timeline as well as the celery task identification
         for the indexing.
+        In error cases, the tuple it returns is an error string and a task_id
+        of -1.
     """
 
     if not my_sketch or not hasattr(my_sketch, "id"):
-        return "Sketch needs to be set"
+        return "Sketch needs to be set", -1
 
     _, _, file_extension = file_path.rpartition(".")
     if file_extension.lower() not in ("plaso", "csv", "jsonl"):
@@ -85,10 +87,10 @@ def upload_file(
             "File needs to have one of the following extensions: "
             ".plaso, .csv, "
             ".jsonl (not {0:s})"
-        ).format(file_extension.lower())
+        ).format(file_extension.lower()), -1
 
     if os.path.getsize(file_path) <= 0:
-        return "File cannot be empty"
+        return "File cannot be empty", -1
     import_helper = helper.ImportHelper()
     import_helper.add_config_dict(config_dict)
 


### PR DESCRIPTION
The function's type tagging indicates a single string, although the function documentation says it returns a tuple.  In fact, the function sometimes returns an error string, and sometimes returns a tuple.

This change updates the typing info and returns -1 as the task_id in error conditions. Resolves https://github.com/google/timesketch/issues/1767

**IMPORTANT: All Pull Requests should be connected to an issue, if you don't
have an issue, please start by creating an issue and link it to the PR.**

Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or adding a minor bug fix -->

+ What existing problem does this PR solve?
+ What new feature is being introduced with this PR?
+ Overview of changes to existing functions if required.

<!-- Example: This PR adds a function to do X, which adds the ability to do Y.
-->

**Checks**

- [ ] All tests succeed.
- [ ] Unit tests added.
- [ ] e2e tests added.
- [ ] Documentation updated.

**Closing issues**

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes
(if such).
